### PR TITLE
fix: use errors.Is for error type assertion

### DIFF
--- a/dissect/error.go
+++ b/dissect/error.go
@@ -2,8 +2,9 @@ package dissect
 
 import (
 	"errors"
-	"github.com/klauspost/compress/zstd"
 	"io"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 var ErrInvalidFile = errors.New("dissect: not a dissect file")
@@ -14,5 +15,5 @@ var ErrInvalidStringSep = errors.New("dissect: invalid string separator")
 // Ok returns true if err only pertains to EOF (read was successful).
 func Ok(err error) bool {
 	// zstd.ErrMagicMismatch is expected at EOF because .rec files have extra non-compressed data.
-	return err == nil || err == io.EOF || err == zstd.ErrMagicMismatch
+	return err == nil || errors.Is(err, io.EOF) || errors.Is(err, zstd.ErrMagicMismatch)
 }


### PR DESCRIPTION
Tiny fix:

Comparing errors with `==` is bug-prone as it doesn't return `true` if the checked error type is wrapped in the error (e.g. by using `fmt.Errorf` with `%w`).
The recommended way to assert error type assertion is using [`errors.Is`](https://pkg.go.dev/errors#Is).

See also the [official error value FAQ](https://github.com/golang/go/wiki/ErrorValueFAQ).

Note: since neither the `io` nor the `zstd` library seem to return wrapped errors, it's not an issue in your usecase, but maybe it will be in the future 😉 