### PR TITLE
feat: Add Y8S3 support

### DIFF
--- a/dissect/header.go
+++ b/dissect/header.go
@@ -76,7 +76,7 @@ const (
 	Ranked           MatchType = 2
 	CustomGameLocal  MatchType = 7
 	CustomGameOnline MatchType = 8
-	Unranked         MatchType = 12
+	Standard         MatchType = 12
 
 	Bomb       GameMode = 327933806
 	SecureArea GameMode = 1983085217
@@ -187,6 +187,7 @@ const (
 	Maestro     Operator = 104189662175
 	Clash       Operator = 104189662280
 	Fenrir      Operator = 288200867339
+	Ram         Operator = 395943091136
 )
 
 // duplicated code here could be avoided by defining a generic function accepting any Number type.

--- a/dissect/matchtype_string.go
+++ b/dissect/matchtype_string.go
@@ -12,13 +12,13 @@ func _() {
 	_ = x[Ranked-2]
 	_ = x[CustomGameLocal-7]
 	_ = x[CustomGameOnline-8]
-	_ = x[Unranked-12]
+	_ = x[Standard-12]
 }
 
 const (
 	_MatchType_name_0 = "QuickMatchRanked"
 	_MatchType_name_1 = "CustomGameLocalCustomGameOnline"
-	_MatchType_name_2 = "Unranked"
+	_MatchType_name_2 = "Standard"
 )
 
 var (

--- a/dissect/operator_roles.go
+++ b/dissect/operator_roles.go
@@ -37,6 +37,7 @@ var _operatorRoles = map[Operator]TeamRole{
 	378305069945: Defense,
 	384797789346: Attack,
 	391752120891: Defense,
+	395943091136: Attack,
 	92270641980:  Defense,
 	92270642032:  Attack,
 	92270642084:  Attack,

--- a/dissect/operator_string.go
+++ b/dissect/operator_string.go
@@ -8,6 +8,7 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[Recruit-359656345734]
 	_ = x[Castle-92270642682]
 	_ = x[Aruni-104189664704]
 	_ = x[Kaid-161289666230]
@@ -76,9 +77,10 @@ func _() {
 	_ = x[Maestro-104189662175]
 	_ = x[Clash-104189662280]
 	_ = x[Fenrir-288200867339]
+	_ = x[Ram-395943091136]
 }
 
-const _Operator_name = "KapkanFuzeGlazBlackbeardValkyrieEchoHibanaLesionYingMuteSledgeSmokeThatcherBuckFrostBanditBlitzIQJagerAshCastlePulseThermiteDocMontagneRookTwitchElaZofiaCapitaoCaveiraDokkaebiVigilMiraJackalLionFinkaAlibiMaestroClashMaverickWardenNokkAmaruGoyoWamaiKaliIanaOryxMelusiAceAruniKaidNomadGridlockMozzieBravaFenrirThunderbirdOsaZeroTachankaFloresThornGrimAzamiSensSolis"
+const _Operator_name = "KapkanFuzeGlazBlackbeardValkyrieEchoHibanaLesionYingMuteSledgeSmokeThatcherBuckFrostBanditBlitzIQJagerAshCastlePulseThermiteDocMontagneRookTwitchElaZofiaCapitaoCaveiraDokkaebiVigilMiraJackalLionFinkaAlibiMaestroClashMaverickWardenNokkAmaruGoyoWamaiKaliIanaOryxMelusiAceAruniKaidNomadGridlockMozzieBravaFenrirThunderbirdOsaZeroTachankaFloresRecruitThornGrimAzamiSensSolisRam"
 
 var _Operator_map = map[Operator]string{
 	92270641980:  _Operator_name[0:6],
@@ -144,11 +146,13 @@ var _Operator_map = map[Operator]string{
 	291191151607: _Operator_name[322:326],
 	291437347686: _Operator_name[326:334],
 	328397386974: _Operator_name[334:340],
-	373711624351: _Operator_name[340:345],
-	374667788042: _Operator_name[345:349],
-	378305069945: _Operator_name[349:354],
-	384797789346: _Operator_name[354:358],
-	391752120891: _Operator_name[358:363],
+	359656345734: _Operator_name[340:347],
+	373711624351: _Operator_name[347:352],
+	374667788042: _Operator_name[352:356],
+	378305069945: _Operator_name[356:361],
+	384797789346: _Operator_name[361:365],
+	391752120891: _Operator_name[365:370],
+	395943091136: _Operator_name[370:373],
 }
 
 func (i Operator) String() string {

--- a/dissect/version.go
+++ b/dissect/version.go
@@ -6,4 +6,5 @@ const (
 	Y7S4 int = 7338571
 	Y8S1 int = 7408213
 	Y8S2 int = 7601998
+	Y8S3 int = 7762708
 )


### PR DESCRIPTION
* Add new operator `Ram`
* Change match type name from `Unranked` to `Standard`
* Add Y8S3 version code

## Known Issue

* Output `xlsx` file is broken

##

Tested & verified with new replay files:
- [ ]  Quick Match
- [x] Standard
- [ ] Ranked