### PR TITLE
fix: team index

### DIFF
--- a/dissect/player.go
+++ b/dissect/player.go
@@ -140,7 +140,6 @@ func readPlayer(r *Reader) error {
 			(r.Header.CodeVersion <= Y7S2 && strings.HasPrefix(p.Username, existing.Username)) {
 			r.Header.Players[i].ProfileID = p.ProfileID
 			r.Header.Players[i].Username = p.Username
-			r.Header.Players[i].TeamIndex = p.TeamIndex
 			r.Header.Players[i].Operator = p.Operator
 			r.Header.Players[i].Spawn = p.Spawn
 			r.Header.Players[i].DissectID = p.DissectID


### PR DESCRIPTION
This PR fixes an issue where the player teamIndex is incorrect, in particular on players that reconnect.