### PR TITLE
fix: Y9S1 match feedback

### DIFF
--- a/dissect/defuse.go
+++ b/dissect/defuse.go
@@ -1,8 +1,9 @@
 package dissect
 
 import (
-	"github.com/rs/zerolog/log"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 func readDefuserTimer(r *Reader) error {

--- a/dissect/site.go
+++ b/dissect/site.go
@@ -1,12 +1,12 @@
 package dissect
 
 import (
-	"github.com/rs/zerolog/log"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 func readSpawn(r *Reader) error {
-	log.Debug().Msg("site found")
 	location, err := r.String()
 	if err != nil {
 		return err


### PR DESCRIPTION
The kill feed broke in Y9S1. This PR resolves the problem.

Messages, such as players leaving or anti-cheat bans will not be available for the time being. Ubisoft changed the format of match feedback / kill feed, likely to something more efficient.