### PR TITLE
Fix: Improves defuser event detection

### DIFF
--- a/dissect/defuse.go
+++ b/dissect/defuse.go
@@ -1,6 +1,7 @@
 package dissect
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -11,6 +12,13 @@ func readDefuserTimer(r *Reader) error {
 	if err != nil {
 		return err
 	}
+	prevTimer := r.lastDefuserTimer
+	timerValue := -1.0
+	if len(timer) > 0 {
+		if v, parseErr := strconv.ParseFloat(timer, 64); parseErr == nil {
+			timerValue = v
+		}
+	}
 	if err = r.Skip(34); err != nil {
 		return err
 	}
@@ -20,10 +28,18 @@ func readDefuserTimer(r *Reader) error {
 	}
 	i := r.PlayerIndexByID(id)
 	a := DefuserPlantStart
+	recordStartEvent := true
 	if r.planted {
-		a = DefuserDisableStart
+		if timerValue >= 0 && prevTimer >= 0 && timerValue > prevTimer {
+			a = DefuserDisableStart
+			r.defuserDisabling = true
+		} else {
+			recordStartEvent = false
+		}
+	} else {
+		r.defuserDisabling = false
 	}
-	if i > -1 {
+	if recordStartEvent && i > -1 {
 		u := MatchUpdate{
 			Type:          a,
 			Username:      r.Header.Players[i].Username,
@@ -36,20 +52,30 @@ func readDefuserTimer(r *Reader) error {
 	}
 	// TODO: 0.00 can be present even if defuser was not disabled.
 	if !strings.HasPrefix(timer, "0.00") {
+		r.lastDefuserTimer = timerValue
 		return nil
 	}
-	a = DefuserDisableComplete
+	eventType := DefuserDisableComplete
 	if !r.planted {
-		a = DefuserPlantComplete
+		eventType = DefuserPlantComplete
 		r.planted = true
+		r.defuserDisabling = false
+	} else if r.defuserDisabling {
+		eventType = DefuserDisableComplete
+		r.defuserDisabling = false
+		r.planted = false
+	} else {
+		r.lastDefuserTimer = timerValue
+		return nil
 	}
 	u := MatchUpdate{
-		Type:          a,
+		Type:          eventType,
 		Username:      r.Header.Players[r.lastDefuserPlayerIndex].Username,
 		Time:          r.timeRaw,
 		TimeInSeconds: r.time,
 	}
 	r.MatchFeedback = append(r.MatchFeedback, u)
 	log.Debug().Interface("match_update", u).Send()
+	r.lastDefuserTimer = timerValue
 	return nil
 }

--- a/dissect/reader.go
+++ b/dissect/reader.go
@@ -26,6 +26,8 @@ type Reader struct {
 	timeRaw                  string  // raw dissect format
 	lastDefuserPlayerIndex   int
 	planted                  bool
+	defuserDisabling         bool
+	lastDefuserTimer         float64
 	readPartial              bool // reads up to the player info packets
 	playersRead              int
 	lastKillerFromScoreboard string


### PR DESCRIPTION
Improves the reliability of defuser plant/disable detection logic by tracking defuser timer values and using them to determine the correct event type.

This fixes issues where the wrong event was being triggered in certain scenarios, particularly around defuser disables. It also handles cases where a timer of 0.00 can appear without a defuser being disabled. Additionally, uses the Y9S4 header information to determine round wins more accurately.